### PR TITLE
trigger build for win64 3.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [s390x]
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - coloredlogs = coloredlogs.cli:main


### PR DESCRIPTION
This package is missing the Python 3.10 version on `win64`, which is required by `onnxruntime`.