### PR TITLE
Rebuild for windows, python 3.12

### DIFF
--- a/recipe/fix-path-error-on-win.patch
+++ b/recipe/fix-path-error-on-win.patch
@@ -1,0 +1,20 @@
+This fixes an error where the path '/' is attempted to be converted from a
+relative to absolute path on windows, resulting in a ValueError.
+
+Note that this patch stops setup.py ... bdist_wheel --universal from being
+called, so this patch may need to be reconsidered if we want this to be made a
+noarch: python package for any reason.
+Index: python-coloredlogs/setup.py
+===================================================================
+--- python-coloredlogs.orig/setup.py
++++ python-coloredlogs/setup.py
+@@ -80,8 +80,7 @@ def find_pth_directory():
+     ``*.pth`` files are installed in the ``lib/pythonX.Y/site-packages``
+     directory without hard coding its location.
+     """
+-    return ('/' if 'bdist_wheel' in sys.argv
+-            else os.path.relpath(distutils.sysconfig.get_python_lib(), sys.prefix))
++    return (os.path.relpath(distutils.sysconfig.get_python_lib(), sys.prefix))
+ 
+ 
+ setup(name='coloredlogs',

--- a/recipe/fix-path-error-on-win.patch
+++ b/recipe/fix-path-error-on-win.patch
@@ -1,9 +1,6 @@
 This fixes an error where the path '/' is attempted to be converted from a
 relative to absolute path on windows, resulting in a ValueError.
 
-Note that this patch stops setup.py ... bdist_wheel --universal from being
-called, so this patch may need to be reconsidered if we want this to be made a
-noarch: python package for any reason.
 Index: python-coloredlogs/setup.py
 ===================================================================
 --- python-coloredlogs.orig/setup.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,3 @@ extra:
     - ocefpaf
     - andfoy
     - ccordoba12
-  skip-lints:
-    - missing_license_url
-    - missing_doc_source_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
   host:
     - python
     - pip
-    - humanfriendly >=9.1
     - setuptools
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 2
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation --ignore-installed -v .
   entry_points:
     - coloredlogs = coloredlogs.cli:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - fix-path-error-on-win.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - coloredlogs = coloredlogs.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   url: https://pypi.io/packages/source/c/coloredlogs/coloredlogs-{{ version }}.tar.gz
   sha256: 7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0
+  patches:
+    - fix-path-error-on-win.patch  # [win]
 
 build:
   number: 1
@@ -15,6 +17,8 @@ build:
     - coloredlogs = coloredlogs.cli:main
 
 requirements:
+  build:
+    - m2-patch  # [win]
   host:
     - python
     - pip


### PR DESCRIPTION

- Patch to get it building on windows (see commit and patch for details)
  - note that windows packages exist for the same recipe. (just not python 3.12). Don't know how it was build before. Last updates were a while ago, so maybe using concourse.
- Bump build number as the recipe is now different, and build for all platforms